### PR TITLE
Fix in if statement

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 TAG=
-F1TV_EMAIL=
-F1TV_PASSWORD=
+F1TV_EMAIL=formula1@example.com
+F1TV_PASSWORD=SuperSecretPassword
 LANGUAGE=eng
 LIVE=false
 RECORD=true

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 TAG=
-F1TV_EMAIL=formula1@example.com
-F1TV_PASSWORD=SuperSecretPassword
+F1TV_EMAIL=
+F1TV_PASSWORD=
 LANGUAGE=eng
 LIVE=false
 RECORD=true

--- a/app/f1tv.sh
+++ b/app/f1tv.sh
@@ -18,9 +18,9 @@ fi
 if [ -z $RECORD ]; then
   RECORD=false
 fi
-if [ -z $OUTPUT ] & [ $RECORD == true ]; then
+if [[ -z $OUTPUT && $RECORD == true ]]; then
   OUTPUT='/record'
-elif [ -z $OUTPUT ] & [ $RECORD == false ]; then
+elif [[ -z $OUTPUT && $RECORD == false ]]; then
   OUTPUT='rtmp://127.0.0.1:1935/live/f1tv'
 fi
 


### PR DESCRIPTION
Because of the single '&' the if process was backgrounded.
This resulted in the default output despite it being in the environment and picked up correctly by the container.

```
root@e65af529b37a:/record# echo $OUTPUT
rtmp://xxx.yyy/live/f1tv

[tcp @ 0x55c5ab8464e0] Connection to tcp://127.0.0.1:1935 failed: Connection refused                                                                                                                               
[rtmp @ 0x55c5ab742280] Cannot open connection tcp://127.0.0.1:1935                                                                                                                                                
rtmp://127.0.0.1:1935/live/f1tv: Connection refused 
```